### PR TITLE
Support elm/http 2.0.0

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -10,7 +10,6 @@
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
-        "elm/http": "1.0.0 <= v < 2.0.0",
         "elm/regex": "1.0.0 <= v < 2.0.0",
         "elm/url": "1.0.0 <= v < 2.0.0",
         "rluiten/stringdistance": "1.0.4 <= v < 2.0.0"

--- a/src/Mailcheck.elm
+++ b/src/Mailcheck.elm
@@ -48,7 +48,6 @@ This is a port of this javascript library <https://github.com/mailcheck/mailchec
 -}
 
 import Dict
-import Http
 import Maybe
 import MaybeUtils exposing (thenOneOf)
 import Regex
@@ -479,8 +478,6 @@ encodeEmail email =
     case encodeEmailReplaceRegex of
         Just regex ->
             email
-                -- replacing encodeUri completely
-                -- |> Http.encodeUri
                 |> percentEncode
                 |> Regex.replace
                     -- Regex.All

--- a/src/Mailcheck.elm
+++ b/src/Mailcheck.elm
@@ -463,7 +463,7 @@ characters, following this official spec:
 This is exported to test it.
 
 encodeURI() will not encode: ~!@#$&\*()=:/,;?+'
-Elm's Http.uriEncode actually calls encodeURIComponent
+Elm's Url.percentEncode actually calls encodeURIComponent
 
 encodeURIComponent() escapes all characters except the
 following: alphabetic, decimal digits, - \_ . ! ~ \* ' ( )


### PR DESCRIPTION
Hey @rluiten, thanks for the awesome package!

We were looking to update our version of `elm/http`, and noticed that it was incompatible with the version in your package. However, it looks like we can just remove the dependency here as it's not actually being used.

Let me know if I can help in any other way. Thanks again!