### PR TITLE
Adds gmail and aol to secondary domains

### DIFF
--- a/src/Mailcheck.elm
+++ b/src/Mailcheck.elm
@@ -321,6 +321,8 @@ defaultSecondLevelDomains =
     , "live"
     , "outlook"
     , "gmx"
+    , "gmail"
+    , "aol"
     ]
 
 


### PR DESCRIPTION
Adds gmail and aol to the secondary domain so it doesn't correct to @mail.com when the input ends in @gmail.com.

## Current behavior:
![gmailsuggestion](https://user-images.githubusercontent.com/14812464/57414897-dbf49c00-71ae-11e9-8166-896976a4de54.gif)